### PR TITLE
Increment Kaiju version

### DIFF
--- a/recipes/kaiju/meta.yaml
+++ b/recipes/kaiju/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.6.0" %}
+{% set version = "1.6.1" %}
 
 package:
   name: kaiju


### PR DESCRIPTION
This PR increments the Kaiju version from 1.6.0 to 1.6.1, which I forgot to do in my prior PR.